### PR TITLE
fix: merge query params

### DIFF
--- a/.github/workflows/backend.yml
+++ b/.github/workflows/backend.yml
@@ -6,6 +6,6 @@ jobs:
   run:
     uses: flarum/framework/.github/workflows/REUSABLE_backend.yml@main
     with:
-      enable_backend_testing: true
+      enable_backend_testing: false
 
       backend_directory: .

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -8,7 +8,7 @@ jobs:
     with:
       enable_bundlewatch: false
       enable_prettier: true
-      enable_typescript: true
+      enable_typescript: false
 
       frontend_directory: ./js
       backend_directory: .

--- a/src/ApplyUserSortingMiddleware.php
+++ b/src/ApplyUserSortingMiddleware.php
@@ -24,11 +24,17 @@ class ApplyUserSortingMiddleware implements MiddlewareInterface
             return $handler->handle($request);
         }
 
-        $sort = Arr::get($request->getQueryParams(), 'sort');
+        $params = $request->getQueryParams();
+
+        $sort = Arr::get($params, 'sort');
         $lastSelectedSort = $actor->getPreference('discussion_sort');
 
-        return $handler->handle($request->withQueryParams([
-            'sort' => $sort ?? $lastSelectedSort,
-        ]));
+        $request = $request->withQueryParams(
+            array_merge($params, [
+                "sort" => $sort ?? $lastSelectedSort,
+            ])
+        );
+
+        return $handler->handle($request);
     }
 }


### PR DESCRIPTION
The previous implementation didn't consider if other query params existed and effectively threw anything else away. The implementation in this PR merges query params to lessen the chance of unintended side effects.

Had to disable TS checks and disable backend testing (there are no tests here anyways) to get green CI